### PR TITLE
Enable performance event support

### DIFF
--- a/arch/arm64/boot/dts/G92X_common.dtsi
+++ b/arch/arm64/boot/dts/G92X_common.dtsi
@@ -2137,4 +2137,12 @@
 		pinctrl-0 = <&simslot_irq>;
 		gpios = <&gpr3 3 0>;
 	};
+
+	pmu {
+		compatible = "arm,armv8-pmuv3";
+		interrupts = <0 60 4>,
+			     <0 61 4>,
+			     <0 62 4>,
+			     <0 63 4>;
+	};
 };

--- a/arch/arm64/configs/hacker_defconfig
+++ b/arch/arm64/configs/hacker_defconfig
@@ -163,7 +163,7 @@ CONFIG_PERF_USE_VMALLOC=y
 #
 # Kernel Performance Events And Counters
 #
-# CONFIG_PERF_EVENTS is not set
+CONFIG_PERF_EVENTS=y
 CONFIG_VM_EVENT_COUNTERS=y
 # CONFIG_SLUB_DEBUG is not set
 # CONFIG_COMPAT_BRK is not set


### PR DESCRIPTION
This patch enables support for the perf interface by defining the corresponding
kernel configuration flag and extending the device tree by the required entry.
